### PR TITLE
feat: add odooly client with Odoo 12 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Here is the description how we develop MCP Servers for our customers: https://ww
 - 🔗 **Execute Methods**: Call custom methods on Odoo models
 - 📋 **List Models**: Discover available models in your Odoo instance
 - 🔧 **Model Introspection**: Get field definitions for any model
+- ✅ **Odoo 12+ Compatibility**: Uses the [Odooly](https://pypi.org/project/odooly/) library to communicate with Odoo, ensuring support for versions 12 and later
 
 ## Installation
 

--- a/mcp_server_odoo/__main__.py
+++ b/mcp_server_odoo/__main__.py
@@ -1,7 +1,8 @@
 """Main entry point for the MCP server."""
 
-from .server import main
 import asyncio
+
+from .server import main
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/mcp_server_odoo/odoo_client.py
+++ b/mcp_server_odoo/odoo_client.py
@@ -1,10 +1,13 @@
-"""Odoo XML-RPC client for API communication."""
+"""Odoo client based on the odooly library."""
 
-import xmlrpc.client
-from typing import Any, Dict, List, Optional, Union
-from urllib.parse import urljoin
+from typing import Any, cast
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field
+
+try:
+    from odooly import Client as OdoolyClient  # type: ignore
+except Exception:  # pragma: no cover - odooly might not be installed in tests
+    OdoolyClient = None  # type: ignore
 
 
 class OdooConfig(BaseModel):
@@ -13,179 +16,170 @@ class OdooConfig(BaseModel):
     url: str = Field(..., description="Odoo instance URL")
     database: str = Field(..., description="Odoo database name")
     username: str = Field(..., description="Odoo username (e.g. email)")
-    password: Optional[str] = Field(None, description="Odoo password")
-    api_key: Optional[str] = Field(None, description="Odoo API key")
+    password: str | None = Field(None, description="Odoo password")
+    api_key: str | None = Field(None, description="Odoo API key")
     timeout: int = Field(120, description="Request timeout in seconds")
 
-    def model_post_init(self, __context: Any) -> None:
+    def model_post_init(self, __context: Any) -> None:  # pragma: no cover - pydantic hook
         """Validate that either password or api_key is provided."""
         if not self.password and not self.api_key:
             raise ValueError("Either password or api_key must be provided")
 
 
 class OdooClient:
-    """Client for interacting with Odoo via XML-RPC."""
+    """Client for interacting with Odoo via the odooly library."""
 
     def __init__(self, config: OdooConfig) -> None:
         """Initialize Odoo client with configuration."""
+        if OdoolyClient is None:  # pragma: no cover - handled in tests
+            raise ImportError("odooly is required to use OdooClient")
+
         self.config = config
         self.url = config.url.rstrip("/")
         self.database = config.database
         self.username = config.username
         self.password = config.api_key or config.password
-        self.uid: Optional[int] = None
-        
-        # Initialize XML-RPC endpoints
-        self.common = xmlrpc.client.ServerProxy(
-            urljoin(self.url, "/xmlrpc/2/common"),
-            allow_none=True,
-            use_builtin_types=True,
-        )
-        self.models = xmlrpc.client.ServerProxy(
-            urljoin(self.url, "/xmlrpc/2/object"),
-            allow_none=True,
-            use_builtin_types=True,
-        )
+        self.timeout = config.timeout
+        self.uid: int | None = None
 
+        # Initialise odooly client and environment
+        self.client = OdoolyClient(
+            self.url,
+            self.database,
+            self.username,
+            self.password,
+            timeout=self.timeout,
+        )
+        self.env = self.client.env
+
+    # ------------------------------------------------------------------
+    # Authentication
+    # ------------------------------------------------------------------
     def authenticate(self) -> int:
         """Authenticate with Odoo and return user ID."""
         if self.uid is None:
-            self.uid = self.common.authenticate(
+            self.uid = self.client.authenticate(
                 self.database,
                 self.username,
                 self.password,
-                {}
+                {},
             )
             if not self.uid:
                 raise ValueError("Authentication failed. Check your credentials.")
         return self.uid
 
-    def execute(
-        self,
-        model: str,
-        method: str,
-        *args: Any,
-        **kwargs: Any
-    ) -> Any:
-        """Execute a method on an Odoo model."""
-        uid = self.authenticate()
-        return self.models.execute_kw(
-            self.database,
-            uid,
-            self.password,
-            model,
-            method,
-            args,
-            kwargs
-        )
-
+    # ------------------------------------------------------------------
+    # CRUD operations
+    # ------------------------------------------------------------------
     def search(
         self,
         model: str,
-        domain: Optional[List[List[Any]]] = None,
+        domain: list[list[Any]] | None = None,
         offset: int = 0,
-        limit: Optional[int] = None,
-        order: Optional[str] = None,
-    ) -> List[int]:
+        limit: int | None = None,
+        order: str | None = None,
+    ) -> Any:
         """Search for record IDs matching the domain."""
         domain = domain or []
-        kwargs: Dict[str, Any] = {"offset": offset}
+        kwargs: dict[str, Any] = {"offset": offset}
         if limit is not None:
             kwargs["limit"] = limit
         if order is not None:
             kwargs["order"] = order
-            
-        return self.execute(model, "search", domain, **kwargs)
+
+        return self.env[model].search(domain, **kwargs)
 
     def search_read(
         self,
         model: str,
-        domain: Optional[List[List[Any]]] = None,
-        fields: Optional[List[str]] = None,
+        domain: list[list[Any]] | None = None,
+        fields: list[str] | None = None,
         offset: int = 0,
-        limit: Optional[int] = None,
-        order: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
+        limit: int | None = None,
+        order: str | None = None,
+    ) -> Any:
         """Search and read records in a single call."""
         domain = domain or []
-        kwargs: Dict[str, Any] = {"offset": offset}
+        kwargs: dict[str, Any] = {"offset": offset}
         if fields is not None:
             kwargs["fields"] = fields
         if limit is not None:
             kwargs["limit"] = limit
         if order is not None:
             kwargs["order"] = order
-            
-        return self.execute(model, "search_read", domain, **kwargs)
+
+        return self.env[model].search_read(domain, **kwargs)
 
     def read(
         self,
         model: str,
-        ids: Union[int, List[int]],
-        fields: Optional[List[str]] = None,
-    ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+        ids: int | list[int],
+        fields: list[str] | None = None,
+    ) -> Any:
         """Read records by IDs."""
         if isinstance(ids, int):
             ids = [ids]
-            
-        kwargs: Dict[str, Any] = {}
+
+        kwargs: dict[str, Any] = {}
         if fields is not None:
             kwargs["fields"] = fields
-            
-        result = self.execute(model, "read", ids, **kwargs)
+
+        result = self.env[model].read(ids, **kwargs)
         return result[0] if len(ids) == 1 else result
 
     def create(
         self,
         model: str,
-        values: Union[Dict[str, Any], List[Dict[str, Any]]],
-    ) -> Union[int, List[int]]:
+        values: dict[str, Any] | list[dict[str, Any]],
+    ) -> Any:
         """Create one or more records."""
         single_record = isinstance(values, dict)
         if single_record:
-            values = [values]
-            
-        result = self.execute(model, "create", values)
+            values_to_create = [cast(dict[str, Any], values)]
+        else:
+            values_to_create = cast(list[dict[str, Any]], values)
+
+        result = self.env[model].create(values_to_create)
         return result[0] if single_record else result
 
     def write(
         self,
         model: str,
-        ids: Union[int, List[int]],
-        values: Dict[str, Any],
-    ) -> bool:
+        ids: int | list[int],
+        values: dict[str, Any],
+    ) -> Any:
         """Update records."""
         if isinstance(ids, int):
             ids = [ids]
-            
-        return self.execute(model, "write", ids, values)
+
+        return self.env[model].write(ids, values)
 
     def unlink(
         self,
         model: str,
-        ids: Union[int, List[int]],
-    ) -> bool:
+        ids: int | list[int],
+    ) -> Any:
         """Delete records."""
         if isinstance(ids, int):
             ids = [ids]
-            
-        return self.execute(model, "unlink", ids)
+
+        return self.env[model].unlink(ids)
 
     def fields_get(
         self,
         model: str,
-        fields: Optional[List[str]] = None,
-        attributes: Optional[List[str]] = None,
-    ) -> Dict[str, Dict[str, Any]]:
+        fields: list[str] | None = None,
+        attributes: list[str] | None = None,
+    ) -> Any:
         """Get field definitions for a model."""
-        kwargs: Dict[str, Any] = {}
+        kwargs: dict[str, Any] = {}
         if fields is not None:
-            kwargs["allfields"] = fields
+            kwargs["fields"] = fields
         if attributes is not None:
             kwargs["attributes"] = attributes
-            
-        return self.execute(model, "fields_get", **kwargs)
 
-    def get_model_list(self) -> List[Dict[str, Any]]:
+        return self.env[model].fields_get(**kwargs)
+
+    def get_model_list(self) -> Any:
         """Get list of all available models."""
-        return self.search_read("ir.model", [], ["model", "name", "transient"])
+        return self.env["ir.model"].search_read([], ["model", "name", "transient"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",
     "httpx>=0.27.0",
+    "odooly>=2.0.0",
 ]
 
 [project.urls]

--- a/tests/test_odoo_client.py
+++ b/tests/test_odoo_client.py
@@ -1,7 +1,9 @@
-"""Tests for Odoo client."""
+"""Tests for Odoo client based on odooly."""
+
+from unittest.mock import MagicMock, patch
 
 import pytest
-from unittest.mock import MagicMock, patch
+
 from mcp_server_odoo.odoo_client import OdooClient, OdooConfig
 
 
@@ -19,17 +21,18 @@ def odoo_config():
 
 @pytest.fixture
 def odoo_client(odoo_config):
-    """Create Odoo client with mocked XML-RPC."""
-    with patch("xmlrpc.client.ServerProxy"):
+    """Create Odoo client with mocked odooly backend."""
+    with patch("mcp_server_odoo.odoo_client.OdoolyClient") as mock_client_cls:
+        mock_client = mock_client_cls.return_value
+        mock_client.env = MagicMock()
+        mock_client.authenticate = MagicMock(return_value=123)
         client = OdooClient(odoo_config)
-        client.common = MagicMock()
-        client.models = MagicMock()
         return client
 
 
 class TestOdooConfig:
     """Test OdooConfig validation."""
-    
+
     def test_valid_config_with_password(self):
         """Test valid config with password."""
         config = OdooConfig(
@@ -40,7 +43,7 @@ class TestOdooConfig:
         )
         assert config.password == "test_pass"
         assert config.api_key is None
-        
+
     def test_valid_config_with_api_key(self):
         """Test valid config with API key."""
         config = OdooConfig(
@@ -51,7 +54,7 @@ class TestOdooConfig:
         )
         assert config.api_key == "test_key"
         assert config.password is None
-        
+
     def test_invalid_config_no_auth(self):
         """Test config without password or API key."""
         with pytest.raises(ValueError, match="Either password or api_key must be provided"):
@@ -64,151 +67,164 @@ class TestOdooConfig:
 
 class TestOdooClient:
     """Test OdooClient methods."""
-    
+
     def test_authenticate_success(self, odoo_client):
         """Test successful authentication."""
-        odoo_client.common.authenticate.return_value = 123
-        
         uid = odoo_client.authenticate()
-        
         assert uid == 123
         assert odoo_client.uid == 123
-        odoo_client.common.authenticate.assert_called_once_with(
-            "test_db", "test_user", "test_pass", {}
-        )
-        
+        odoo_client.client.authenticate.assert_called_once()
+
     def test_authenticate_failure(self, odoo_client):
         """Test authentication failure."""
-        odoo_client.common.authenticate.return_value = False
-        
+        odoo_client.client.authenticate.return_value = False
+        odoo_client.uid = None
         with pytest.raises(ValueError, match="Authentication failed"):
             odoo_client.authenticate()
-            
+
     def test_search_records(self, odoo_client):
         """Test search method."""
-        odoo_client.uid = 123
-        odoo_client.models.execute_kw.return_value = [1, 2, 3]
-        
+        model = MagicMock()
+        model.search.return_value = [1, 2, 3]
+        odoo_client.env.__getitem__.return_value = model
+
         result = odoo_client.search(
             "res.partner",
             [["name", "ilike", "test"]],
             limit=10,
-            order="name asc"
+            order="name asc",
         )
-        
+
         assert result == [1, 2, 3]
-        odoo_client.models.execute_kw.assert_called_once_with(
-            "test_db",
-            123,
-            "test_pass",
-            "res.partner",
-            "search",
-            ([["name", "ilike", "test"]],),
-            {"offset": 0, "limit": 10, "order": "name asc"}
+        model.search.assert_called_once_with(
+            [["name", "ilike", "test"]], offset=0, limit=10, order="name asc"
         )
-        
+
     def test_search_read(self, odoo_client):
         """Test search_read method."""
-        odoo_client.uid = 123
-        expected_result = [
+        model = MagicMock()
+        expected = [
             {"id": 1, "name": "Test Partner 1"},
             {"id": 2, "name": "Test Partner 2"},
         ]
-        odoo_client.models.execute_kw.return_value = expected_result
-        
+        model.search_read.return_value = expected
+        odoo_client.env.__getitem__.return_value = model
+
         result = odoo_client.search_read(
             "res.partner",
             [["active", "=", True]],
             fields=["name", "email"],
-            limit=5
+            limit=5,
         )
-        
-        assert result == expected_result
-        
+
+        assert result == expected
+        model.search_read.assert_called_once_with(
+            [["active", "=", True]],
+            offset=0,
+            fields=["name", "email"],
+            limit=5,
+        )
+
     def test_read_single_record(self, odoo_client):
         """Test reading a single record."""
-        odoo_client.uid = 123
-        odoo_client.models.execute_kw.return_value = [{"id": 1, "name": "Test"}]
-        
+        model = MagicMock()
+        model.read.return_value = [{"id": 1, "name": "Test"}]
+        odoo_client.env.__getitem__.return_value = model
+
         result = odoo_client.read("res.partner", 1, ["name"])
-        
+
         assert result == {"id": 1, "name": "Test"}
-        
+        model.read.assert_called_once_with([1], fields=["name"])
+
     def test_read_multiple_records(self, odoo_client):
         """Test reading multiple records."""
-        odoo_client.uid = 123
+        model = MagicMock()
         expected = [{"id": 1, "name": "Test1"}, {"id": 2, "name": "Test2"}]
-        odoo_client.models.execute_kw.return_value = expected
-        
+        model.read.return_value = expected
+        odoo_client.env.__getitem__.return_value = model
+
         result = odoo_client.read("res.partner", [1, 2], ["name"])
-        
+
         assert result == expected
-        
+        model.read.assert_called_once_with([1, 2], fields=["name"])
+
     def test_create_single_record(self, odoo_client):
         """Test creating a single record."""
-        odoo_client.uid = 123
-        odoo_client.models.execute_kw.return_value = [42]
-        
+        model = MagicMock()
+        model.create.return_value = [42]
+        odoo_client.env.__getitem__.return_value = model
+
         result = odoo_client.create("res.partner", {"name": "New Partner"})
-        
+
         assert result == 42
-        
+        model.create.assert_called_once_with([{"name": "New Partner"}])
+
     def test_create_multiple_records(self, odoo_client):
         """Test creating multiple records."""
-        odoo_client.uid = 123
-        odoo_client.models.execute_kw.return_value = [42, 43]
-        
+        model = MagicMock()
+        model.create.return_value = [42, 43]
+        odoo_client.env.__getitem__.return_value = model
+
         result = odoo_client.create(
             "res.partner",
-            [{"name": "Partner 1"}, {"name": "Partner 2"}]
+            [{"name": "Partner 1"}, {"name": "Partner 2"}],
         )
-        
+
         assert result == [42, 43]
-        
+        model.create.assert_called_once_with([{"name": "Partner 1"}, {"name": "Partner 2"}])
+
     def test_write_records(self, odoo_client):
         """Test updating records."""
-        odoo_client.uid = 123
-        odoo_client.models.execute_kw.return_value = True
-        
+        model = MagicMock()
+        model.write.return_value = True
+        odoo_client.env.__getitem__.return_value = model
+
         result = odoo_client.write(
             "res.partner",
             [1, 2],
-            {"active": False}
+            {"active": False},
         )
-        
+
         assert result is True
-        
+        model.write.assert_called_once_with([1, 2], {"active": False})
+
     def test_unlink_records(self, odoo_client):
         """Test deleting records."""
-        odoo_client.uid = 123
-        odoo_client.models.execute_kw.return_value = True
-        
+        model = MagicMock()
+        model.unlink.return_value = True
+        odoo_client.env.__getitem__.return_value = model
+
         result = odoo_client.unlink("res.partner", [1, 2])
-        
+
         assert result is True
-        
+        model.unlink.assert_called_once_with([1, 2])
+
     def test_fields_get(self, odoo_client):
         """Test getting field definitions."""
-        odoo_client.uid = 123
+        model = MagicMock()
         expected = {
             "name": {"type": "char", "string": "Name", "required": True},
             "email": {"type": "char", "string": "Email"},
         }
-        odoo_client.models.execute_kw.return_value = expected
-        
+        model.fields_get.return_value = expected
+        odoo_client.env.__getitem__.return_value = model
+
         result = odoo_client.fields_get("res.partner", ["name", "email"])
-        
+
         assert result == expected
-        
+        model.fields_get.assert_called_once_with(fields=["name", "email"])
+
     def test_get_model_list(self, odoo_client):
         """Test getting model list."""
-        odoo_client.uid = 123
+        model = MagicMock()
         expected = [
             {"model": "res.partner", "name": "Contact", "transient": False},
             {"model": "sale.order", "name": "Sales Order", "transient": False},
         ]
-        odoo_client.models.execute_kw.return_value = expected
-        
+        model.search_read.return_value = expected
+        odoo_client.env.__getitem__.return_value = model
+
         result = odoo_client.get_model_list()
-        
+
         assert result == expected
+        model.search_read.assert_called_once_with([], ["model", "name", "transient"])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,9 +1,11 @@
 """Tests for MCP server."""
 
 import json
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-from mcp_server_odoo.server import server, get_odoo_client, call_tool
+
+from mcp_server_odoo.server import call_tool
 
 
 @pytest.fixture
@@ -29,15 +31,21 @@ def mock_env(monkeypatch):
     monkeypatch.setenv("ODOO_PASSWORD", "test_pass")
 
 
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
 class TestServer:
     """Test MCP server functionality."""
-    
-    @pytest.mark.asyncio
+
+    @pytest.mark.anyio
     async def test_list_tools(self):
         """Test listing available tools."""
         from mcp_server_odoo.server import list_tools
+
         tools = await list_tools()
-        
+
         tool_names = [tool.name for tool in tools]
         assert "search_records" in tool_names
         assert "create_record" in tool_names
@@ -46,8 +54,8 @@ class TestServer:
         assert "get_record" in tool_names
         assert "list_models" in tool_names
         assert "get_model_fields" in tool_names
-        
-    @pytest.mark.asyncio
+
+    @pytest.mark.anyio
     async def test_search_records_tool(self, mock_odoo_client, mock_env):
         """Test search_records tool."""
         with patch("mcp_server_odoo.server.get_odoo_client", return_value=mock_odoo_client):
@@ -55,96 +63,81 @@ class TestServer:
                 {"id": 1, "name": "Test Partner"},
                 {"id": 2, "name": "Another Partner"},
             ]
-            
+
             result = await call_tool(
                 "search_records",
                 {
                     "model": "res.partner",
                     "domain": [["name", "ilike", "test"]],
                     "fields": ["name", "email"],
-                    "limit": 10
-                }
+                    "limit": 10,
+                },
             )
-            
+
             assert len(result) == 1
             assert result[0].type == "text"
             data = json.loads(result[0].text)
             assert len(data) == 2
             assert data[0]["name"] == "Test Partner"
-            
-    @pytest.mark.asyncio
+
+    @pytest.mark.anyio
     async def test_create_record_tool(self, mock_odoo_client, mock_env):
         """Test create_record tool."""
         with patch("mcp_server_odoo.server.get_odoo_client", return_value=mock_odoo_client):
             mock_odoo_client.create.return_value = 42
-            
+
             result = await call_tool(
                 "create_record",
                 {
                     "model": "res.partner",
-                    "values": {"name": "New Partner", "email": "new@example.com"}
-                }
+                    "values": {"name": "New Partner", "email": "new@example.com"},
+                },
             )
-            
+
             assert len(result) == 1
             assert "Created record with ID: 42" in result[0].text
-            
-    @pytest.mark.asyncio
+
+    @pytest.mark.anyio
     async def test_update_record_tool(self, mock_odoo_client, mock_env):
         """Test update_record tool."""
         with patch("mcp_server_odoo.server.get_odoo_client", return_value=mock_odoo_client):
             mock_odoo_client.write.return_value = True
-            
+
             result = await call_tool(
                 "update_record",
-                {
-                    "model": "res.partner",
-                    "ids": [1, 2],
-                    "values": {"active": False}
-                }
+                {"model": "res.partner", "ids": [1, 2], "values": {"active": False}},
             )
-            
+
             assert len(result) == 1
             assert "Update successful" in result[0].text
-            
-    @pytest.mark.asyncio
+
+    @pytest.mark.anyio
     async def test_delete_record_tool(self, mock_odoo_client, mock_env):
         """Test delete_record tool."""
         with patch("mcp_server_odoo.server.get_odoo_client", return_value=mock_odoo_client):
             mock_odoo_client.unlink.return_value = True
-            
-            result = await call_tool(
-                "delete_record",
-                {
-                    "model": "res.partner",
-                    "ids": [1, 2]
-                }
-            )
-            
+
+            result = await call_tool("delete_record", {"model": "res.partner", "ids": [1, 2]})
+
             assert len(result) == 1
             assert "Delete successful" in result[0].text
-            
-    @pytest.mark.asyncio
+
+    @pytest.mark.anyio
     async def test_get_record_tool(self, mock_odoo_client, mock_env):
         """Test get_record tool."""
         with patch("mcp_server_odoo.server.get_odoo_client", return_value=mock_odoo_client):
             mock_odoo_client.read.return_value = {"id": 1, "name": "Test Partner"}
-            
+
             result = await call_tool(
-                "get_record",
-                {
-                    "model": "res.partner",
-                    "ids": [1],
-                    "fields": ["name", "email"]
-                }
+                "get_record", {"model": "res.partner", "ids": [1], "fields": ["name", "email"]}
             )
-            
+
             assert len(result) == 1
             data = json.loads(result[0].text)
             assert data["id"] == 1
             assert data["name"] == "Test Partner"
-            
-    @pytest.mark.asyncio
+
+    @pytest.mark.anyio
     async def test_list_models_tool(self, mock_odoo_client, mock_env):
         """Test list_models tool."""
         with patch("mcp_server_odoo.server.get_odoo_client", return_value=mock_odoo_client):
@@ -153,15 +146,15 @@ class TestServer:
                 {"model": "sale.order", "name": "Sales Order", "transient": False},
                 {"model": "wizard.test", "name": "Test Wizard", "transient": True},
             ]
-            
+
             result = await call_tool("list_models", {"transient": False})
-            
+
             assert len(result) == 1
             assert "res.partner: Contact" in result[0].text
             assert "sale.order: Sales Order" in result[0].text
             assert "wizard.test" not in result[0].text
-            
-    @pytest.mark.asyncio
+
+    @pytest.mark.anyio
     async def test_get_model_fields_tool(self, mock_odoo_client, mock_env):
         """Test get_model_fields tool."""
         with patch("mcp_server_odoo.server.get_odoo_client", return_value=mock_odoo_client):
@@ -169,35 +162,32 @@ class TestServer:
                 "name": {"type": "char", "string": "Name"},
                 "email": {"type": "char", "string": "Email"},
             }
-            
+
             result = await call_tool(
-                "get_model_fields",
-                {"model": "res.partner", "fields": ["name", "email"]}
+                "get_model_fields", {"model": "res.partner", "fields": ["name", "email"]}
             )
-            
+
             assert len(result) == 1
             data = json.loads(result[0].text)
             assert "name" in data
             assert data["name"]["type"] == "char"
-            
-    @pytest.mark.asyncio
+
+    @pytest.mark.anyio
     async def test_error_handling(self, mock_odoo_client, mock_env):
         """Test error handling in tools."""
         with patch("mcp_server_odoo.server.get_odoo_client", return_value=mock_odoo_client):
             mock_odoo_client.search_read.side_effect = Exception("Connection error")
-            
-            result = await call_tool(
-                "search_records",
-                {"model": "res.partner"}
-            )
-            
+
+            result = await call_tool("search_records", {"model": "res.partner"})
+
             assert len(result) == 1
             assert "Error: Exception: Connection error" in result[0].text
-            
-    @pytest.mark.asyncio
+
+    @pytest.mark.anyio
     async def test_unknown_tool(self, mock_env):
         """Test calling unknown tool."""
-        result = await call_tool("unknown_tool", {})
-        
+        with patch("mcp_server_odoo.server.get_odoo_client"):
+            result = await call_tool("unknown_tool", {})
+
         assert len(result) == 1
         assert "Unknown tool: unknown_tool" in result[0].text


### PR DESCRIPTION
## Summary
- switch XML-RPC client to Odooly-based implementation
- add Odoo 12 compatibility note and dependency
- update tests to run with anyio backend

## Testing
- `ruff check mcp_server_odoo/odoo_client.py mcp_server_odoo/server.py mcp_server_odoo/__main__.py tests/test_odoo_client.py tests/test_server.py`
- `mypy mcp_server_odoo`
- `pytest`